### PR TITLE
Update Debian Security example to "stable-security"

### DIFF
--- a/release.go
+++ b/release.go
@@ -93,13 +93,13 @@ type Release struct {
 	// directly beneath dists/. As an example, security updates are specified
 	// in APT as:
 	//
-	// deb http://security.debian.org/ stable/updates main)
+	// deb http://security.debian.org/debian-security stable-security main)
 	//
 	// The Release file would be located at
-	// http://security.debian.org/dists/stable/updates/Release and look like:
+	// http://security.debian.org/dists/stable-security/Release and look like:
 	//
-	//   Suite: stable
-	//   Components: updates/main updates/contrib updates/non-free
+	//   Suite: stable-security
+	//   Components: main contrib non-free
 	Components []string `delim:" "`
 
 	// Whitespace separated unique single words identifying Debian machine


### PR DESCRIPTION
Fixes https://bugs.debian.org/970065

I'm not sure how you want to handle this, since this updated example won't actually work until bullseye is released, but figured I'd open the upstream PR to have the discussion here. :+1:

FYI/cc @pabs3 :heart: